### PR TITLE
Fix iOS13 Crash

### DIFF
--- a/GTHalfSheet/GTSheet/Animators/DismissalAnimator.swift
+++ b/GTHalfSheet/GTSheet/Animators/DismissalAnimator.swift
@@ -14,6 +14,7 @@ public class DismissalAnimator: UIPercentDrivenInteractiveTransition, UIViewCont
 
     var isFromGesture: Bool = false
     var animator: UIViewPropertyAnimator?
+    var interuptableAnimator: UIViewImplicitlyAnimating?
 
     public init(manager: HalfSheetPresentationManager) {
         super.init()
@@ -25,14 +26,19 @@ public class DismissalAnimator: UIPercentDrivenInteractiveTransition, UIViewCont
     }
 
     public func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
-        return transition(using: transitionContext)
+        guard let interupt = interuptableAnimator else {
+            interuptableAnimator = transition(using: transitionContext)
+            return interuptableAnimator!
+        }
+
+        return interupt
     }
 
     public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        transition(using: transitionContext)
+        interuptableAnimator = transition(using: transitionContext)
     }
 
-    @discardableResult private func transition(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
+    private func transition(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
 
         let presentedControllerView = transitionContext.view(forKey: UITransitionContextViewKey.from)!
 


### PR DESCRIPTION
From the docs it looks like you need to hold onto the instance of the transition: https://developer.apple.com/documentation/uikit/uiviewcontrolleranimatedtransitioning/1829434-interruptibleanimatorfortransiti?language=objc

Resolves https://github.com/gametimesf/GTSheet/issues/19